### PR TITLE
feat!: allow multiple bindings on virtual element

### DIFF
--- a/packages/analyzer/src/standard/transpile.ts
+++ b/packages/analyzer/src/standard/transpile.ts
@@ -34,7 +34,9 @@ export function transpile(document: Document) {
 
   document.visit(
     (node) => {
-      render(node.binding);
+      for (const binding of node.bindings) {
+        render(binding);
+      }
     },
     { filter: KoVirtualElement },
   );

--- a/packages/location/src/index.ts
+++ b/packages/location/src/index.ts
@@ -1,3 +1,3 @@
-export { default as Position } from "./position.js";
-export { default as Range } from "./range.js";
+export { default as Position, type RawPosition } from "./position.js";
+export { default as Range, type RawRange } from "./range.js";
 export * from "./utils.js";

--- a/packages/parser/src/__snapshots__/parser.test.ts.snap
+++ b/packages/parser/src/__snapshots__/parser.test.ts.snap
@@ -2,6 +2,251 @@
 
 exports[`parser Deep virtual elements 1`] = `
 {
+  "children": [
+    {
+      "bindings": [
+        {
+          "end": {
+            "column": 16,
+            "line": 0,
+            "offset": 16,
+          },
+          "incomplete": false,
+          "name": {
+            "end": {
+              "column": 11,
+              "line": 0,
+              "offset": 11,
+            },
+            "start": {
+              "column": 8,
+              "line": 0,
+              "offset": 8,
+            },
+            "value": "foo",
+          },
+          "param": {
+            "end": {
+              "column": 16,
+              "line": 0,
+              "offset": 16,
+            },
+            "start": {
+              "column": 13,
+              "line": 0,
+              "offset": 13,
+            },
+            "value": "foo",
+          },
+          "start": {
+            "column": 8,
+            "line": 0,
+            "offset": 8,
+          },
+        },
+      ],
+      "children": [
+        {
+          "bindings": [
+            {
+              "end": {
+                "column": 36,
+                "line": 0,
+                "offset": 36,
+              },
+              "incomplete": false,
+              "name": {
+                "end": {
+                  "column": 31,
+                  "line": 0,
+                  "offset": 31,
+                },
+                "start": {
+                  "column": 28,
+                  "line": 0,
+                  "offset": 28,
+                },
+                "value": "bar",
+              },
+              "param": {
+                "end": {
+                  "column": 36,
+                  "line": 0,
+                  "offset": 36,
+                },
+                "start": {
+                  "column": 33,
+                  "line": 0,
+                  "offset": 33,
+                },
+                "value": "bar",
+              },
+              "start": {
+                "column": 28,
+                "line": 0,
+                "offset": 28,
+              },
+            },
+          ],
+          "children": [],
+          "end": {
+            "column": 52,
+            "line": 0,
+            "offset": 52,
+          },
+          "endComment": {
+            "content": " /ko ",
+            "end": {
+              "column": 52,
+              "line": 0,
+              "offset": 52,
+            },
+            "start": {
+              "column": 40,
+              "line": 0,
+              "offset": 40,
+            },
+            "type": "comment",
+          },
+          "expression": {
+            "end": {
+              "column": 36,
+              "line": 0,
+              "offset": 36,
+            },
+            "start": {
+              "column": 28,
+              "line": 0,
+              "offset": 28,
+            },
+            "value": "bar: bar",
+          },
+          "inner": {
+            "end": {
+              "column": 40,
+              "line": 0,
+              "offset": 40,
+            },
+            "start": {
+              "column": 40,
+              "line": 0,
+              "offset": 40,
+            },
+          },
+          "namespace": {
+            "end": {
+              "column": 27,
+              "line": 0,
+              "offset": 27,
+            },
+            "start": {
+              "column": 25,
+              "line": 0,
+              "offset": 25,
+            },
+            "value": "ko",
+          },
+          "start": {
+            "column": 20,
+            "line": 0,
+            "offset": 20,
+          },
+          "startComment": {
+            "content": " ko bar: bar ",
+            "end": {
+              "column": 40,
+              "line": 0,
+              "offset": 40,
+            },
+            "start": {
+              "column": 20,
+              "line": 0,
+              "offset": 20,
+            },
+            "type": "comment",
+          },
+          "type": "virtual-element",
+        },
+      ],
+      "end": {
+        "column": 64,
+        "line": 0,
+        "offset": 64,
+      },
+      "endComment": {
+        "content": " /ko ",
+        "end": {
+          "column": 64,
+          "line": 0,
+          "offset": 64,
+        },
+        "start": {
+          "column": 52,
+          "line": 0,
+          "offset": 52,
+        },
+        "type": "comment",
+      },
+      "expression": {
+        "end": {
+          "column": 16,
+          "line": 0,
+          "offset": 16,
+        },
+        "start": {
+          "column": 8,
+          "line": 0,
+          "offset": 8,
+        },
+        "value": "foo: foo",
+      },
+      "inner": {
+        "end": {
+          "column": 52,
+          "line": 0,
+          "offset": 52,
+        },
+        "start": {
+          "column": 20,
+          "line": 0,
+          "offset": 20,
+        },
+      },
+      "namespace": {
+        "end": {
+          "column": 7,
+          "line": 0,
+          "offset": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 0,
+          "offset": 5,
+        },
+        "value": "ko",
+      },
+      "start": {
+        "column": 0,
+        "line": 0,
+        "offset": 0,
+      },
+      "startComment": {
+        "content": " ko foo: foo ",
+        "end": {
+          "column": 20,
+          "line": 0,
+          "offset": 20,
+        },
+        "start": {
+          "column": 0,
+          "line": 0,
+          "offset": 0,
+        },
+        "type": "comment",
+      },
+      "type": "virtual-element",
+    },
+  ],
   "end": {
     "column": 64,
     "line": 0,
@@ -17,10 +262,324 @@ exports[`parser Deep virtual elements 1`] = `
 
 exports[`parser Element bindings 1`] = `
 {
+  "children": [
+    {
+      "attributes": [
+        {
+          "end": {
+            "column": 23,
+            "line": 0,
+            "offset": 23,
+          },
+          "name": {
+            "end": {
+              "column": 14,
+              "line": 0,
+              "offset": 14,
+            },
+            "start": {
+              "column": 5,
+              "line": 0,
+              "offset": 5,
+            },
+            "value": "data-bind",
+          },
+          "namespace": null,
+          "prefix": null,
+          "start": {
+            "column": 5,
+            "line": 0,
+            "offset": 5,
+          },
+          "value": {
+            "end": {
+              "column": 23,
+              "line": 0,
+              "offset": 23,
+            },
+            "inner": {
+              "end": {
+                "column": 22,
+                "line": 0,
+                "offset": 22,
+              },
+              "start": {
+                "column": 16,
+                "line": 0,
+                "offset": 16,
+              },
+            },
+            "quote": "'",
+            "start": {
+              "column": 15,
+              "line": 0,
+              "offset": 15,
+            },
+            "value": "0: bar",
+          },
+        },
+      ],
+      "bindings": [
+        {
+          "end": {
+            "column": 22,
+            "line": 0,
+            "offset": 22,
+          },
+          "incomplete": false,
+          "name": {
+            "end": {
+              "column": 17,
+              "line": 0,
+              "offset": 17,
+            },
+            "start": {
+              "column": 16,
+              "line": 0,
+              "offset": 16,
+            },
+            "value": "0",
+          },
+          "param": {
+            "end": {
+              "column": 22,
+              "line": 0,
+              "offset": 22,
+            },
+            "start": {
+              "column": 19,
+              "line": 0,
+              "offset": 19,
+            },
+            "value": "bar",
+          },
+          "start": {
+            "column": 16,
+            "line": 0,
+            "offset": 16,
+          },
+        },
+      ],
+      "children": [],
+      "end": {
+        "column": 30,
+        "line": 0,
+        "offset": 30,
+      },
+      "inner": {
+        "end": {
+          "column": 24,
+          "line": 0,
+          "offset": 24,
+        },
+        "start": {
+          "column": 24,
+          "line": 0,
+          "offset": 24,
+        },
+      },
+      "start": {
+        "column": 0,
+        "line": 0,
+        "offset": 0,
+      },
+      "tagName": {
+        "end": {
+          "column": 4,
+          "line": 0,
+          "offset": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 0,
+          "offset": 1,
+        },
+        "value": "div",
+      },
+      "type": "element",
+    },
+  ],
   "end": {
     "column": 30,
     "line": 0,
     "offset": 30,
+  },
+  "start": {
+    "column": 0,
+    "line": 0,
+    "offset": 0,
+  },
+}
+`;
+
+exports[`parser Multiple bindings on same virtual element 1`] = `
+{
+  "children": [
+    {
+      "bindings": [
+        {
+          "end": {
+            "column": 17,
+            "line": 0,
+            "offset": 17,
+          },
+          "incomplete": false,
+          "name": {
+            "end": {
+              "column": 12,
+              "line": 0,
+              "offset": 12,
+            },
+            "start": {
+              "column": 8,
+              "line": 0,
+              "offset": 8,
+            },
+            "value": "with",
+          },
+          "param": {
+            "end": {
+              "column": 17,
+              "line": 0,
+              "offset": 17,
+            },
+            "start": {
+              "column": 14,
+              "line": 0,
+              "offset": 14,
+            },
+            "value": "foo",
+          },
+          "start": {
+            "column": 8,
+            "line": 0,
+            "offset": 8,
+          },
+        },
+        {
+          "end": {
+            "column": 28,
+            "line": 0,
+            "offset": 28,
+          },
+          "incomplete": false,
+          "name": {
+            "end": {
+              "column": 21,
+              "line": 0,
+              "offset": 21,
+            },
+            "start": {
+              "column": 19,
+              "line": 0,
+              "offset": 19,
+            },
+            "value": "as",
+          },
+          "param": {
+            "end": {
+              "column": 28,
+              "line": 0,
+              "offset": 28,
+            },
+            "start": {
+              "column": 23,
+              "line": 0,
+              "offset": 23,
+            },
+            "value": "'bar'",
+          },
+          "start": {
+            "column": 19,
+            "line": 0,
+            "offset": 19,
+          },
+        },
+      ],
+      "children": [],
+      "end": {
+        "column": 44,
+        "line": 0,
+        "offset": 44,
+      },
+      "endComment": {
+        "content": " /ko ",
+        "end": {
+          "column": 44,
+          "line": 0,
+          "offset": 44,
+        },
+        "start": {
+          "column": 32,
+          "line": 0,
+          "offset": 32,
+        },
+        "type": "comment",
+      },
+      "expression": {
+        "end": {
+          "column": 28,
+          "line": 0,
+          "offset": 28,
+        },
+        "start": {
+          "column": 8,
+          "line": 0,
+          "offset": 8,
+        },
+        "value": "with: foo, as: 'bar'",
+      },
+      "inner": {
+        "end": {
+          "column": 32,
+          "line": 0,
+          "offset": 32,
+        },
+        "start": {
+          "column": 32,
+          "line": 0,
+          "offset": 32,
+        },
+      },
+      "namespace": {
+        "end": {
+          "column": 7,
+          "line": 0,
+          "offset": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 0,
+          "offset": 5,
+        },
+        "value": "ko",
+      },
+      "start": {
+        "column": 0,
+        "line": 0,
+        "offset": 0,
+      },
+      "startComment": {
+        "content": " ko with: foo, as: 'bar' ",
+        "end": {
+          "column": 32,
+          "line": 0,
+          "offset": 32,
+        },
+        "start": {
+          "column": 0,
+          "line": 0,
+          "offset": 0,
+        },
+        "type": "comment",
+      },
+      "type": "virtual-element",
+    },
+  ],
+  "end": {
+    "column": 44,
+    "line": 0,
+    "offset": 44,
   },
   "start": {
     "column": 0,

--- a/packages/parser/src/parser.test.ts
+++ b/packages/parser/src/parser.test.ts
@@ -22,4 +22,9 @@ describe("parser", () => {
   test("Import statement with *", () => {
     parse("<!-- ok with: * from 'foo' --><!-- /ok -->");
   });
+
+  test("Multiple bindings on same virtual element", () => {
+    const { document } = parse("<!-- ko with: foo, as: 'bar' --><!-- /ko -->");
+    expect(document).toMatchSnapshot();
+  });
 });

--- a/packages/syntax-tree/src/syntax-tree/binding.ts
+++ b/packages/syntax-tree/src/syntax-tree/binding.ts
@@ -1,7 +1,12 @@
 import type { Attribute, Element } from "./element.js";
-import type { Expression, Identifier } from "./primitives.js";
+import type {
+  Expression,
+  Identifier,
+  RawExpression,
+  RawIdentifier,
+} from "./primitives.js";
 import type { KoVirtualElement } from "./virtual-element.js";
-import { Range } from "@knuckles/location";
+import { Range, type RawRange } from "@knuckles/location";
 
 export interface BindingInit {
   name: Identifier;
@@ -11,10 +16,16 @@ export interface BindingInit {
   incomplete?: boolean | undefined;
 }
 
+export interface RawBinding extends RawRange {
+  name: RawIdentifier;
+  param: RawExpression;
+  incomplete: boolean;
+}
+
 export class Binding extends Range {
   name: Identifier;
   param: Expression;
-  attribute: Attribute | null;
+  attribute: Attribute | undefined;
   parent: Element | KoVirtualElement;
   incomplete: boolean;
 
@@ -22,8 +33,17 @@ export class Binding extends Range {
     super(init.name.start, init.param.end);
     this.name = init.name;
     this.param = init.param;
-    this.attribute = init.attribute ?? null;
+    this.attribute = init.attribute ?? undefined;
     this.parent = init.parent;
     this.incomplete = init.incomplete ?? false;
+  }
+
+  override toJSON(): RawBinding {
+    return {
+      ...super.toJSON(),
+      name: this.name.toJSON(),
+      param: this.param.toJSON(),
+      incomplete: this.incomplete,
+    };
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/comment.ts
+++ b/packages/syntax-tree/src/syntax-tree/comment.ts
@@ -1,6 +1,11 @@
-import { Node, type NodeInit } from "./node.js";
+import { Node, type NodeInit, type RawNode } from "./node.js";
 
 export interface CommentInit extends NodeInit {
+  content: string;
+}
+
+export interface RawComment extends RawNode {
+  type: "comment";
   content: string;
 }
 
@@ -10,5 +15,13 @@ export class Comment extends Node {
   constructor(init: CommentInit) {
     super(init);
     this.content = init.content;
+  }
+
+  override toJSON(): RawComment {
+    return {
+      ...super.toJSON(),
+      type: "comment",
+      content: this.content,
+    };
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/document.ts
+++ b/packages/syntax-tree/src/syntax-tree/document.ts
@@ -1,9 +1,15 @@
-import { ParentNode, type ParentNodeInit } from "./node.js";
+import { ParentNode, type ParentNodeInit, type RawParentNode } from "./node.js";
 
 export interface DocumentInit extends ParentNodeInit {}
+
+export interface RawDocument extends RawParentNode {}
 
 export class Document extends ParentNode {
   constructor(init: DocumentInit) {
     super(init);
+  }
+
+  override toJSON(): RawDocument {
+    return super.toJSON();
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/element.ts
+++ b/packages/syntax-tree/src/syntax-tree/element.ts
@@ -1,7 +1,17 @@
-import type { Binding } from "./binding.js";
-import { type Node, ParentNode, type ParentNodeInit } from "./node.js";
-import type { Identifier, StringLiteral } from "./primitives.js";
-import { Range } from "@knuckles/location";
+import type { Binding, RawBinding } from "./binding.js";
+import {
+  type Node,
+  ParentNode,
+  type ParentNodeInit,
+  type RawParentNode,
+} from "./node.js";
+import type {
+  Identifier,
+  RawIdentifier,
+  RawStringLiteral,
+  StringLiteral,
+} from "./primitives.js";
+import { Range, type RawRange } from "@knuckles/location";
 
 export interface ElementInit extends ParentNodeInit {
   tagName: Identifier;
@@ -9,6 +19,14 @@ export interface ElementInit extends ParentNodeInit {
   bindings: Iterable<Binding>;
   children: Iterable<Node>;
   inner: Range;
+}
+
+export interface RawElement extends RawParentNode {
+  type: "element";
+  tagName: RawIdentifier;
+  attributes: RawAttribute[];
+  bindings: RawBinding[];
+  inner: RawRange;
 }
 
 export class Element extends ParentNode {
@@ -24,6 +42,17 @@ export class Element extends ParentNode {
     this.bindings = Array.from(init.bindings);
     this.inner = init.inner;
   }
+
+  override toJSON(): RawElement {
+    return {
+      ...super.toJSON(),
+      type: "element",
+      tagName: this.tagName.toJSON(),
+      attributes: this.attributes.map((attribute) => attribute.toJSON()),
+      bindings: this.bindings.map((binding) => binding.toJSON()),
+      inner: this.inner.toJSON(),
+    };
+  }
 }
 
 export interface AttributeInit {
@@ -36,6 +65,13 @@ export interface AttributeInit {
 }
 
 export type Quotation = "single" | "double";
+
+export interface RawAttribute extends RawRange {
+  name: RawIdentifier;
+  value: RawStringLiteral;
+  namespace: string | null;
+  prefix: string | null;
+}
 
 export class Attribute extends Range {
   name: Identifier;
@@ -51,5 +87,15 @@ export class Attribute extends Range {
     this.namespace = init.namespace ?? null;
     this.prefix = init.prefix ?? null;
     this.parent = init.parent;
+  }
+
+  override toJSON(): RawAttribute {
+    return {
+      ...super.toJSON(),
+      name: this.name.toJSON(),
+      value: this.value.toJSON(),
+      namespace: this.namespace,
+      prefix: this.prefix,
+    };
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/node.ts
+++ b/packages/syntax-tree/src/syntax-tree/node.ts
@@ -1,8 +1,10 @@
-import { type Position, Range } from "@knuckles/location";
+import { type Position, Range, type RawRange } from "@knuckles/location";
 
 export interface NodeInit {
   range: Range;
 }
+
+export interface RawNode extends RawRange {}
 
 export abstract class Node extends Range {
   constructor(init: NodeInit) {
@@ -26,10 +28,18 @@ export abstract class Node extends Range {
       }
     }
   }
+
+  override toJSON(): RawNode {
+    return super.toJSON();
+  }
 }
 
 export interface ParentNodeInit extends NodeInit {
   children: Iterable<Node>;
+}
+
+export interface RawParentNode extends RawRange {
+  children: RawNode[];
 }
 
 export abstract class ParentNode extends Node {
@@ -54,5 +64,12 @@ export abstract class ParentNode extends Node {
     }
 
     return ascendants.reduce((a, b) => (a.size < b.size ? a : b));
+  }
+
+  override toJSON(): RawParentNode {
+    return {
+      ...super.toJSON(),
+      children: this.children.map((child) => child.toJSON()),
+    };
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/primitives.ts
+++ b/packages/syntax-tree/src/syntax-tree/primitives.ts
@@ -1,7 +1,11 @@
-import { Range } from "@knuckles/location";
+import { Range, type RawRange } from "@knuckles/location";
 
 export interface IdentifierInit {
   range: Range;
+  value: string;
+}
+
+export interface RawIdentifier extends RawRange {
   value: string;
 }
 
@@ -12,10 +16,21 @@ export class Identifier extends Range {
     super(init.range.start, init.range.end);
     this.value = init.value;
   }
+
+  override toJSON(): RawIdentifier {
+    return {
+      ...super.toJSON(),
+      value: this.value,
+    };
+  }
 }
 
 export interface ExpressionInit {
   range: Range;
+  value: string;
+}
+
+export interface RawExpression extends RawRange {
   value: string;
 }
 
@@ -26,17 +41,32 @@ export class Expression extends Range {
     super(init.range.start, init.range.end);
     this.value = init.value;
   }
+
+  override toJSON(): RawExpression {
+    return {
+      ...super.toJSON(),
+      value: this.value,
+    };
+  }
 }
 
 export interface StringLiteralInit {
   range: Range;
+  inner: Range;
   value: string;
   quote: '"' | "'" | null;
+}
+
+export interface RawStringLiteral extends RawRange {
+  value: string;
+  quote: '"' | "'" | null;
+  inner: RawRange;
 }
 
 export class StringLiteral extends Range {
   value: string;
   quote: '"' | "'" | null;
+  inner: Range;
 
   get text() {
     return this.quote + this.value + this.quote;
@@ -44,7 +74,17 @@ export class StringLiteral extends Range {
 
   constructor(init: StringLiteralInit) {
     super(init.range.start, init.range.end);
+    this.inner = init.inner;
     this.value = init.value;
     this.quote = init.quote;
+  }
+
+  override toJSON(): RawStringLiteral {
+    return {
+      ...super.toJSON(),
+      value: this.value,
+      quote: this.quote,
+      inner: this.inner.toJSON(),
+    };
   }
 }

--- a/packages/syntax-tree/src/syntax-tree/text.ts
+++ b/packages/syntax-tree/src/syntax-tree/text.ts
@@ -1,6 +1,11 @@
-import { Node, type NodeInit } from "./node.js";
+import { Node, type NodeInit, type RawNode } from "./node.js";
 
 export interface TextInit extends NodeInit {
+  content: string;
+}
+
+export interface RawText extends RawNode {
+  type: "text";
   content: string;
 }
 
@@ -10,5 +15,13 @@ export class Text extends Node {
   constructor(init: TextInit) {
     super(init);
     this.content = init.content;
+  }
+
+  override toJSON(): RawText {
+    return {
+      ...super.toJSON(),
+      type: "text",
+      content: this.content,
+    };
   }
 }


### PR DESCRIPTION
- Update parser to allow multiple bindings on same virtual element node.
- Implement `toJSON` method for all nodes in syntax tree (for testing).